### PR TITLE
chore(renovate): raise release age to 3 days, fix GHCR stability gate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
   "helmfile": {
     "fileMatch": ["^k8s/argocd/argocd-helmfile\\.yaml$"]
   },
-  "minimumReleaseAge": "1 day",
+  "minimumReleaseAge": "3 days",
   "internalChecksFilter": "strict",
   "internalChecksAsSuccess": true,
   "pinDigests": true,
@@ -34,6 +34,14 @@
       "description": "No release-age gate on digests. They track mutable tags that get rebuilt upstream, which resets the age clock every run, so renovate/stability-days hangs pending forever and the branch is never green.",
       "matchUpdateTypes": ["digest", "pinDigest"],
       "minimumReleaseAge": null
+    },
+    {
+      "description": "GHCR and Quay return no release timestamps, so minimumReleaseAge can never pass there: under the default timestamp-required these hang pending forever (PRs #404, #410, #411 sat 3+ weeks). Waive the timestamp requirement and substitute a weekly cadence: picked up Wednesday, auto-merged Saturday. Every update still soaks >=3 days as an open PR, breakage lands with the weekend free to fix it, and a hijacked release stays undiscovered up to a week.",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/**", "quay.io/**"],
+      "minimumReleaseAgeBehaviour": "timestamp-optional",
+      "schedule": ["on wednesday"],
+      "automergeSchedule": ["on saturday"]
     },
     {
       "description": "Always auto-merge (including major) for selected apps",
@@ -86,5 +94,11 @@
       "matchUpdateTypes": ["patch"],
       "automerge": true
     }
-  ]
+  ],
+  "vulnerabilityAlerts": {
+    "description": "Live as of 2026-08-16: Dependabot alerts enabled, Dependabot security updates deliberately left disabled so it never opens PRs competing with Renovate. Coverage is only the actions in .github/workflows - GHSA has no ecosystem for container images or Helm charts, so nothing under k8s/ can fire. GHSA accepts maintainer-published advisories for their own repo without review, so a compromised maintainer could self-advisory past this gate: do not widen it. Malware advisories usually carry no fixed version, so they surface as notifications rather than auto-merged bumps.",
+    "minimumReleaseAge": null,
+    "schedule": ["at any time"],
+    "automergeSchedule": ["at any time"]
+  }
 }


### PR DESCRIPTION
## Problem

GHCR and Quay do not return release timestamps. Under the default `minimumReleaseAgeBehaviour=timestamp-required`, their updates are held **indefinitely** rather than for N days — #404, #410 and #411 sat on a pending `renovate/stability-days` check for 3+ weeks. That affects ~15 of the 21 image references under `k8s/`.

## Change

- `minimumReleaseAge` 1 day → **3 days**, keeping the strict `timestamp-required` default globally. Catches a broken `.0` that gets a `.1` within 48h, which is how container images actually fail.
- New rule for `ghcr.io/**` and `quay.io/**`: `timestamp-optional` plus a weekly cadence — `schedule: on wednesday`, `automergeSchedule: on saturday`. Every update still soaks ≥3 days as an open PR, breakage lands with the weekend free to fix it, and a hijacked release stays undiscovered up to a week.
- `vulnerabilityAlerts` exempted from the age gate and the schedule.

## Notes

The Wednesday/Saturday split works because Renovate's branch worker falls through to the automerge step once the branch and PR already exist, even on an off-schedule run; `automergeSchedule` is then evaluated separately. This relies on `automergeType: "pr"`.

Latency after this change: Helm charts and Docker Hub images 3 days; GHCR/Quay 4–10 days averaging ~7. A weekend-only merge window cannot beat a 7-day tail, since a release landing just after Saturday waits for the next one.

Dependabot alerts have been enabled on the repo; Dependabot **security updates** are deliberately left disabled so it never opens PRs competing with Renovate. Coverage is only the actions in `.github/workflows` — GHSA has no ecosystem for container images or Helm charts.

Validated with `renovate-config-validator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)